### PR TITLE
refactor: add debug logging for citation parsing with detailed context

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -749,14 +749,24 @@ const Chat = () => {
   }
 
   const parseCitationFromMessage = (message: ChatMessage) => {
+    console.log('[CITATION_DEBUG] Processing message:', message?.id, 'Role:', message?.role)
+    
     if (message?.role && message?.role === 'tool' && typeof message?.content === 'string') {
+      console.log('[CITATION_DEBUG] Found tool message with string content')
       try {
         const toolMessage = JSON.parse(message.content) as ToolMessageContent
+        console.log('[CITATION_DEBUG] Parsed tool message:', toolMessage)
+        console.log('[CITATION_DEBUG] Citations found:', toolMessage.citations?.length || 0)
+        if (toolMessage.citations?.length > 0) {
+          console.log('[CITATION_DEBUG] First citation:', JSON.stringify(toolMessage.citations[0]))
+        }
         return toolMessage.citations
-      } catch {
+      } catch (error) {
+        console.error('[CITATION_DEBUG] Error parsing tool message content:', error)
         return []
       }
     }
+    console.log('[CITATION_DEBUG] Message not eligible for citation parsing')
     return []
   }
 


### PR DESCRIPTION
This pull request adds extensive debug logging to the `parseCitationFromMessage` function in `Chat.tsx` to help diagnose issues with citation parsing.

### Debug logging enhancements:

* Added multiple `console.log` statements to log the processing of messages, including their `id`, `role`, and the number of citations found, as well as details about the first citation if available.
* Added a `console.error` statement to log errors encountered while parsing the tool message content.
* Included a fallback log message when a message is not eligible for citation parsing.